### PR TITLE
feat: update weixin auth logic

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
   "browser": true,
   "node": true,
   "es5": true,
+  "esversion": 6,
   "bitwise": true,
   "curly": true,
   "eqeqeq": true,

--- a/api_router_v1.js
+++ b/api_router_v1.js
@@ -26,8 +26,8 @@ router.get('/topic_collect/:loginname', topicCollectController.list);
 
 // 用户
 router.get('/user/:loginname', userController.show);
-router.post('/user/login', userController.login);
-router.post('/user/wxAuth', userController.wxAuth);
+router.post('/user/weixin/bind', userController.weixinBind);
+router.post('/user/weixin/login', userController.weixinLogin);
 router.put('/user', userController.putAction);
 
 

--- a/common/WXBizDataCrypt.js
+++ b/common/WXBizDataCrypt.js
@@ -1,10 +1,14 @@
 var crypto = require('crypto')
 
-function WXBizDataCrypt(appId, secret) {
+function WXBizDataCrypt(appId, sessionKey) {
   return {
+    appId:appId,
+    sessionKey:sessionKey,
     decryptData: function (encryptedData, iv) {
+      console.error(this.appId,this.sessionKey,encryptedData,iv)
+
       // base64 decode
-      var sessionKey = new Buffer(secret, 'base64')
+      var sessionKey = new Buffer(this.sessionKey, 'base64')
       encryptedData = new Buffer(encryptedData, 'base64')
       iv = new Buffer(iv, 'base64')
 
@@ -22,7 +26,7 @@ function WXBizDataCrypt(appId, secret) {
         throw new Error('Illegal Buffer')
       }
 
-      if (decoded.watermark.appid !== appId) {
+      if (decoded.watermark.appid !== this.appId) {
         throw new Error('Illegal Buffer')
       }
 

--- a/common/tools.js
+++ b/common/tools.js
@@ -20,7 +20,8 @@ exports.validateId = function (str) {
 };
 
 exports.bhash = function (str, callback) {
-  bcrypt.hash(str, 10, callback);
+  var res = bcrypt.hashSync(str,10)
+  return callback ? callback(res):res
 };
 
 exports.bcompare = function (str, hash, callback) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eventproxy": "1.0.0",
     "express": "4.16.0",
     "express-session": "1.12.1",
+    "got": "^9.6.0",
     "helmet": "1.3.0",
     "ioredis": "1.15.1",
     "jpush-sdk": "3.3.2",


### PR DESCRIPTION
更新微信登录逻辑

> 添加了got模块

授权接口
```
POST /api/v1/user/weixin/login {"code":"xxx","authInfo":{"encryptedData":"xxx","iv":"xxx","userInfo":{"nickName":"","gender":,"language":"zh_CN","city":"xx","province":"xx","country":"xx","avatarUrl":"xx"}}}
```
返回
```
{"success":true,"data":"xxx"} //data为jwt，携带到url，body字段名为token，携带到头部字段名为x-access-token
```

> 后期可携带jwt进行用户验证，仅限微信端

更新PUT  /api/v1/user 逻辑